### PR TITLE
field note used yet are not hidden. certified icon visible only for c…

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-    locale: 'en'
+    locale: 'fr'
     app.path.images: /uploads/images
     env(S3): false
 

--- a/src/Controller/CardController.php
+++ b/src/Controller/CardController.php
@@ -172,7 +172,10 @@ class CardController extends AbstractController
             $entityManager = $this->getDoctrine()->getManager();
             $entityManager->persist($nomenclature);
             $entityManager->flush();
-            return $this->render('card/upload-success.html.twig');
+            //return $this->render('card/upload-success.html.twig');
+            return $this->render('card/edit.html.twig', [
+              'formNomenclature' => $form->createView(),
+            ]);
         }
 
         return $this->render('card/new.html.twig', [

--- a/src/Entity/Nomenclature.php
+++ b/src/Entity/Nomenclature.php
@@ -64,8 +64,8 @@ class Nomenclature
     const STATUS = [
       0 => 'draft',
       1 => 'waiting-approval',
-      2 => 'validated'
-
+      2 => 'approved',
+      3 => 'certified'
     ];
     /**
      * @ORM\Column(type="integer")

--- a/templates/card/show.html.twig
+++ b/templates/card/show.html.twig
@@ -1,9 +1,11 @@
 <div class="column is-half-widescreen">
   <div class="box">
 
+    {% if nomenclature.status == 3 %}
     <span class="icon is-large is-pulled-right nomenclature-label">
       <i class="fas fa-check-circle fa-3x"></i>
     </span>
+    {% endif %}
 
     <article class="media">
       <div class="media-left">
@@ -28,11 +30,11 @@
       <div class="media-content">
         <h2 class="title is-2">{{nomenclature.name}}</h2>
         <small>{{'by' | trans}} {{ nomenclature.createdBy.username }}</small>
-        <div class="tags">
+        {# <div class="tags">
           <span class="tag">Gospel</span>
           <span class="tag">Chant</span>
           <span class="tag">Religieux</span>
-        </div>
+        </div> #}
 
         <div class="columns">
           <div class="column">
@@ -73,6 +75,7 @@
               </div>
             </div>
           </div>
+          {#
           <div class="column">
             <nav class="level is-mobile">
               <div class="level-left">
@@ -104,7 +107,7 @@
               <p class="title is-5">123</p>
             </div>
           </div>
-        </nav>
+        </nav>#}
       </div>
     </article>
   </div>

--- a/tests/ClassifiedCardControllerTest.php
+++ b/tests/ClassifiedCardControllerTest.php
@@ -31,7 +31,7 @@ class ClassifiedCardControllerTest extends WebTestCase
         ]);
         $crawler = $client->request('GET', '/nomenclature/new');
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('Create a nomenclature', $crawler->filter('h1')->text());
+        $this->assertContains('Créer une nomenclature', $crawler->filter('h1')->text());
     }
 
     public function test_admin_anonymous_must_return_unauthorized()


### PR DESCRIPTION
-  Fields not used yet (number of download, like, etc..) are temporary hidden. 
- Certified state has been added and certified icon is only visible for certified nomenclature.
- Validated Status replaced by approved to be consistent with "waiting-Approval State. 
- Default language set to French. 
- When a new nomenclature is created, edit page is loaded after the submit to force the editor to set correct field information.

